### PR TITLE
Style and formatting cleanup, no functional changes

### DIFF
--- a/Source/BeRDP.cpp
+++ b/Source/BeRDP.cpp
@@ -49,7 +49,7 @@ void BeRDP::MessageReceived (BMessage *message)
 	switch(message->what)
 	{
 		default:
-			BApplication::MessageReceived(message); // pass it along ... 
+			BApplication::MessageReceived(message); // pass it along ...
 			break;
 	}
 }

--- a/Source/BeRDP.cpp
+++ b/Source/BeRDP.cpp
@@ -1,12 +1,13 @@
 /*
+ * Copyright 2003-2018. All rights reserved.
+ * Distributed under the terms of the BSD license.
+ *
+ * Author:
+ *	Sikosis, phil@sikosis.com
+ *
+ * BeRDP is a GUI for RDesktop
+ */
 
-BeRDP
-
-Author: BeRDP
-
-(C)2003
-
-*/
 
 // Includes ------------------------------------------------------------------------------------------ //
 #include <Application.h>

--- a/Source/BeRDP.cpp
+++ b/Source/BeRDP.cpp
@@ -8,8 +8,6 @@
  * BeRDP is a GUI for RDesktop
  */
 
-
-// Includes ------------------------------------------------------------------------------------------ //
 #include <Application.h>
 #include <Screen.h>
 #include <Window.h>
@@ -19,19 +17,17 @@
 #include "BeRDPWindows.h"
 #include "BeRDPViews.h"
 #include "BeRDPConstants.h"
-// Constants ---------------------------------------------------------------------------------------- //
 
 const char *APP_SIGNATURE = "application/x-vnd.BeRDP";  // Application Signature
 
-// -------------------------------------------------------------------------------------------------- //
-
 BeRDPWindow		*ptrBeRDPWindow;
+
 
 // BeRDP - Constructor
 BeRDP::BeRDP() : BApplication (APP_SIGNATURE)
 {
 	// Default Window Size - Position doesn't matter as we centre the form to the current screen size
-	//BRect	screenFrame = (BScreen(B_MAIN_SCREEN_ID).Frame());
+	// BRect	screenFrame = (BScreen(B_MAIN_SCREEN_ID).Frame());
 
 	float FormTopDefault = 0;
 	float FormLeftDefault = 0;
@@ -41,7 +37,7 @@ BeRDP::BeRDP() : BApplication (APP_SIGNATURE)
 
 	ptrBeRDPWindow = new BeRDPWindow(BeRDPWindowRect);
 }
-// ------------------------------------------------------------------------------------------------- //
+
 
 // BeRDP::MessageReceived -- handles incoming messages
 void BeRDP::MessageReceived (BMessage *message)
@@ -53,7 +49,7 @@ void BeRDP::MessageReceived (BMessage *message)
 			break;
 	}
 }
-// ------------------------------------------------------------------------------------------------- //
+
 
 // BeRDP Main
 int main(void)
@@ -62,5 +58,3 @@ int main(void)
 	theApp.Run();
 	return 0;
 }
-// end --------------------------------------------------------------------------------------------- //
-

--- a/Source/BeRDP.h
+++ b/Source/BeRDP.h
@@ -1,12 +1,12 @@
 /*
-
-BeRDP Header
-
-Author: BeRDP
-
-(C)2003 Created using BRIE (http://brie.sf.net/)
-
-*/
+ * Copyright 2003-2018. All rights reserved.
+ * Distributed under the terms of the BSD license.
+ *
+ * Author:
+ *	Sikosis, phil@sikosis.com
+ *
+ * BeRDP is a GUI for RDesktop
+ */
 
 #ifndef __BeRDP_H__
 #define __BeRDP_H__

--- a/Source/BeRDPConstants.h
+++ b/Source/BeRDPConstants.h
@@ -1,12 +1,12 @@
 /*
-
-BeRDP Constants
-
-Author: Sikosis 
-
-(C)2003-2004 BeRDP Team (http://berdp.sf.net/)
-
-*/
+ * Copyright 2003-2018. All rights reserved.
+ * Distributed under the terms of the BSD license.
+ *
+ * Author:
+ *	Sikosis, phil@sikosis.com
+ *
+ * BeRDP is a GUI for RDesktop
+ */
 
 #ifndef __BeRDPCONSTANTS_H__
 #define __BeRDPCONSTANTS_H__

--- a/Source/BeRDPViews.cpp
+++ b/Source/BeRDPViews.cpp
@@ -8,7 +8,7 @@
  * BeRDP is a GUI for RDesktop
  */
 
-// Includes ------------------------------------------------------------------------------------------ //
+
 #include <Alert.h>
 #include <Application.h>
 #include <Screen.h>
@@ -18,21 +18,20 @@
 
 #include "BeRDPWindows.h"
 #include "BeRDPViews.h"
-// -------------------------------------------------------------------------------------------------- //
+
 
 // BeRDPView - Constructor
 BeRDPView::BeRDPView (BRect frame) : BView (frame, "BeRDPView", B_FOLLOW_ALL_SIDES, B_WILL_DRAW )
 {
 	SetViewColor(ui_color(B_PANEL_BACKGROUND_COLOR));
 }
-// ------------------------------------------------------------------------------------------------- //
+
 
 void BeRDPView::Draw(BRect /*updateRect*/)
 {
 	BRect r;
 	r = Bounds();
 }
-// ------------------------------------------------------------------------------------------------- //
 
 
 // GeneralView
@@ -40,7 +39,6 @@ GeneralView::GeneralView (BRect frame) : BView (frame, "GeneralView", B_FOLLOW_A
 {
 	SetViewColor(ui_color(B_PANEL_BACKGROUND_COLOR));
 }
-// ---------------------------------------------------------------------------------------------------------- //
 
 
 // GeneralView - Draw
@@ -49,7 +47,6 @@ void GeneralView::Draw(BRect /*updateRect*/)
 	BRect r;
 	r = Bounds();
 }
-// ---------------------------------------------------------------------------------------------------------- //
 
 
 // DisplayView
@@ -57,7 +54,6 @@ DisplayView::DisplayView (BRect frame) : BView (frame, "DisplayView", B_FOLLOW_A
 {
 	SetViewColor(ui_color(B_PANEL_BACKGROUND_COLOR));
 }
-// ---------------------------------------------------------------------------------------------------------- //
 
 
 // AboutView
@@ -65,5 +61,3 @@ AboutView::AboutView (BRect frame) : BView (frame, "AboutView", B_FOLLOW_ALL_SID
 {
 	SetViewColor(ui_color(B_PANEL_BACKGROUND_COLOR));
 }
-// ---------------------------------------------------------------------------------------------------------- //
-

--- a/Source/BeRDPViews.cpp
+++ b/Source/BeRDPViews.cpp
@@ -1,12 +1,12 @@
 /*
-
-BeRDP View
-
-Author: BeRDP
-
-(C)2003 Created using BRIE (http://brie.sf.net/)
-
-*/
+ * Copyright 2003-2018. All rights reserved.
+ * Distributed under the terms of the BSD license.
+ *
+ * Author:
+ *	Sikosis, phil@sikosis.com
+ *
+ * BeRDP is a GUI for RDesktop
+ */
 
 // Includes ------------------------------------------------------------------------------------------ //
 #include <Alert.h>

--- a/Source/BeRDPViews.h
+++ b/Source/BeRDPViews.h
@@ -1,12 +1,12 @@
 /*
-
-BeRDP Views Header
-
-Author: BeRDP
-
-(C)2003 Created using BRIE (http://brie.sf.net/)
-
-*/
+ * Copyright 2003-2018. All rights reserved.
+ * Distributed under the terms of the BSD license.
+ *
+ * Author:
+ *	Sikosis, phil@sikosis.com
+ *
+ * BeRDP is a GUI for RDesktop
+ */
 
 #ifndef __BeRDPVIEWS_H__
 #define __BeRDPVIEWS_H__

--- a/Source/BeRDPViews.h
+++ b/Source/BeRDPViews.h
@@ -47,6 +47,3 @@ class AboutView : public BView
 };
 
 #endif
-
-
-

--- a/Source/BeRDPWindows.cpp
+++ b/Source/BeRDPWindows.cpp
@@ -64,7 +64,7 @@ BeRDPWindow::BeRDPWindow(BRect frame) : BWindow (frame, "BeRDP", B_TITLED_WINDOW
 	InitWindow();
 	CenterWindowOnScreen(this);
 
-	// Load User Settings 
+	// Load User Settings
 	BPath path;
 	find_directory(B_USER_SETTINGS_DIRECTORY,&path);
 	path.Append("BeRDP/BeRDP_Settings",true);
@@ -72,13 +72,13 @@ BeRDPWindow::BeRDPWindow(BRect frame) : BWindow (frame, "BeRDP", B_TITLED_WINDOW
 	BMessage msg;
 	msg.Unflatten(&file);
 	LoadSettings (&msg);
-    
+
     // Set Window Limits
 	SetSizeLimits(315,315,205,230);
-    
+
     // Update from our Loaded Settings
     UpdateDisplaySlider();
-    
+
 	Show();
 }
 // -------------------------------------------------------------------------------------------------- //
@@ -104,29 +104,29 @@ void BeRDPWindow::InitWindow(void)
     rlist.left += 12;
     rlist.right -= 12;
     rlist.bottom -= 12;
-    
+
     // Create Views for our Tabs
     ptrGeneralView = new GeneralView(r);
     ptrDisplayView = new DisplayView(r);
     ptrAboutView = new AboutView(r);
-    
+
     // Create the Buttons for GeneralView
-	btnConnect = new BButton(BRect (133,150,213,180), 
+	btnConnect = new BButton(BRect (133,150,213,180),
 					"btnConnect","Connect", new BMessage(BTN_CONNECT),
 					B_FOLLOW_LEFT | B_FOLLOW_TOP, B_WILL_DRAW | B_NAVIGABLE);
 	btnConnect->MakeDefault(true);
-	btnConnect->MakeFocus(true);					
-	btnClose = new BButton(BRect (225,150,305,180), 
+	btnConnect->MakeFocus(true);
+	btnClose = new BButton(BRect (225,150,305,180),
 					"btnClose","Close", new BMessage(BTN_CLOSE),
-					B_FOLLOW_LEFT | B_FOLLOW_TOP, B_WILL_DRAW | B_NAVIGABLE);	
+					B_FOLLOW_LEFT | B_FOLLOW_TOP, B_WILL_DRAW | B_NAVIGABLE);
 	ptrGeneralView->AddChild(btnConnect);
     ptrGeneralView->AddChild(btnClose);
-    
-    
+
+
     // Create Connection Menu for GeneralView
     BString DefaultIP;
     DefaultIP.SetTo("Default"); // debug
-    
+
     pmnConnection = new BPopUpMenu("", true, true);
     pmnConnection->AddItem(new BMenuItem(DefaultIP.String(), new BMessage(MENU_CONNECTION_DEFAULT)));
     pmnConnection->AddSeparatorItem();
@@ -138,7 +138,7 @@ void BeRDPWindow::InitWindow(void)
 	mnfConnection->SetDivider(110);
 	mnfConnection->SetFont(be_bold_font);
 	mnfConnection->SetLowColor(ui_color(B_PANEL_BACKGROUND_COLOR));
-	
+
     /*conmenufield = new BMenu(" ... ");
     conmenufield->AddItem(new BMenuItem(DefaultIP.String(), new BMessage(MENU_CONNECTION_DEFAULT)));
     conmenufield->AddSeparatorItem();
@@ -146,10 +146,10 @@ void BeRDPWindow::InitWindow(void)
     conmenufield->AddItem(menucondelete = new BMenuItem("Delete Current", new BMessage(MENU_CON_DELETE_CURRENT)));
     menucondelete->SetEnabled(false);
     connectionmenufield = new BMenuField(BRect (5,25,220,40),"connection_menu","Connection Name:",conmenufield,B_FOLLOW_LEFT | B_FOLLOW_TOP, B_WILL_DRAW | B_NAVIGABLE);
-    connectionmenufield->SetDivider(110);	
+    connectionmenufield->SetDivider(110);
     connectionmenufield->SetFont(be_bold_font);
     connectionmenufield->SetLowColor(ui_color(B_PANEL_BACKGROUND_COLOR));*/
-    
+
     // Create TextControls for GeneralView
     txtComputer = new BTextControl(BRect (30,50,220,65), "txtComputer",
       					"Computer: ", "", new BMessage (TXT_COMPUTER),
@@ -158,14 +158,14 @@ void BeRDPWindow::InitWindow(void)
 	txtUsername = new BTextControl(BRect (30,75,250,90), "txtUsername",
       					"Username: ", "", new BMessage (TXT_USERNAME),
 						B_FOLLOW_LEFT | B_FOLLOW_TOP, B_WILL_DRAW | B_NAVIGABLE);
-	txtUsername->SetDivider(55);					
-    
+	txtUsername->SetDivider(55);
+
     txtPassword = new BTextControl(BRect (30,100,250,115), "txtPassword",
       					"Password: ", "", new BMessage (TXT_PASSWORD),
 						B_FOLLOW_LEFT | B_FOLLOW_TOP, B_WILL_DRAW | B_NAVIGABLE);
-	txtPassword->SetDivider(55);					
+	txtPassword->SetDivider(55);
     txtPassword->SetEnabled(false);
-    
+
     txtDomain = new BTextControl(BRect (30,125,250,140), "txtDomain",
       					"Domain: ", "", new BMessage (TXT_DOMAIN),
 						B_FOLLOW_LEFT | B_FOLLOW_TOP, B_WILL_DRAW | B_NAVIGABLE);
@@ -173,32 +173,32 @@ void BeRDPWindow::InitWindow(void)
 
 	ptrGeneralView->AddChild(mnfConnection);
 	ptrGeneralView->AddChild(txtComputer);
-	ptrGeneralView->AddChild(txtUsername);					
-    ptrGeneralView->AddChild(txtPassword);					
+	ptrGeneralView->AddChild(txtUsername);
+    ptrGeneralView->AddChild(txtPassword);
     ptrGeneralView->AddChild(txtDomain);
-    
+
     // Create CheckBox for Display
     chkForceBitmapUpdates = new BCheckBox(BRect (30,69,300,79), "chkForceBitmapUpdates",
       					"Force Bitmap Updates", new BMessage (CHK_FORCE_BITMAP_UPDATES),
       					B_FOLLOW_LEFT | B_FOLLOW_TOP, B_WILL_DRAW | B_NAVIGABLE);
-    
+
     // Create Slider for Display
     sldDisplaySize = new BSlider(BRect (20,15,r.right - 20,30), "sldDisplaySize",
       					"Full Screen", new BMessage (SLD_DISPLAYSIZE), 0, 5,
       					B_BLOCK_THUMB, B_FOLLOW_LEFT | B_FOLLOW_TOP,
 						B_FRAME_EVENTS|B_WILL_DRAW | B_NAVIGABLE);
 	sldDisplaySize->SetHashMarkCount(1);
-	sldDisplaySize->SetKeyIncrementValue(1);					
+	sldDisplaySize->SetKeyIncrementValue(1);
     sldDisplaySize->SetHashMarks(B_HASH_MARKS_BOTH);
     sldDisplaySize->SetLimitLabels("Less", "More");
-    sldDisplaySize->SetValue(3);  
-    
+    sldDisplaySize->SetValue(3);
+
    // int wsleft = 175;
-    
+
     // Add them all to Display Tab
     ptrDisplayView->AddChild(sldDisplaySize);
     ptrDisplayView->AddChild(chkForceBitmapUpdates);
-          
+
     // Create StringViews for AboutView
     float fLeftMargin = 8;
     float fRightMargin = 310;
@@ -207,8 +207,8 @@ void BeRDPWindow::InitWindow(void)
       				B_FOLLOW_LEFT | B_FOLLOW_TOP, B_WILL_DRAW);
     stvAuthor1 = new BStringView(BRect (fLeftMargin,30,fRightMargin,45), "Author 1", "(C) 2003-2004 Sikosis",
       				B_FOLLOW_LEFT | B_FOLLOW_TOP, B_WILL_DRAW);
-      				
-    
+
+
 	txvDescription = new BTextView(BRect(fLeftMargin, fDescTop, fRightMargin, fDescTop+80),
 						 "Description", BRect(0,0,fRightMargin-fLeftMargin,80), B_FOLLOW_ALL_SIDES, B_WILL_DRAW);
 	txvDescription->SetWordWrap(true);
@@ -216,14 +216,14 @@ void BeRDPWindow::InitWindow(void)
 	txvDescription->SetStylable(true);
 	txvDescription->SetViewColor(ui_color(B_PANEL_BACKGROUND_COLOR));
 	txvDescription->Insert("BeRDP is a GUI for RDesktop, which is used to connect to Microsoft Remote Desktop Protocol servers.\n");
-      				
+
     stvURL = new BStringView(BRect (fLeftMargin,153,r.right,168), "URL", "Website: github.com/HaikuArchives/BeRDP",
       				B_FOLLOW_LEFT | B_FOLLOW_TOP, B_WILL_DRAW);
     ptrAboutView->AddChild(stvAuthor1);
     ptrAboutView->AddChild(stvTitle);
-    ptrAboutView->AddChild(txvDescription); 
-    ptrAboutView->AddChild(stvURL); 				
-        
+    ptrAboutView->AddChild(txvDescription);
+    ptrAboutView->AddChild(stvURL);
+
 	// Create the TabView and Tabs
 	tabView = new BTabView(rtab,"berdp_tabview");
 	tabView->SetViewColor(ui_color(B_PANEL_BACKGROUND_COLOR));
@@ -238,7 +238,7 @@ void BeRDPWindow::InitWindow(void)
 	tab = new BTab();
 	tabView->AddTab(ptrAboutView, tab);
 	tab->SetLabel("About");
-	
+
 	// Create the Views
 	AddChild(ptrBeRDPView = new BeRDPView(r));
 	ptrBeRDPView->AddChild(tabView);
@@ -272,32 +272,32 @@ void BeRDPWindow::LoadSettings(BMessage *msg)
 		MoveTo(frame.left,frame.top);
 		ResizeTo(frame.right-frame.left,frame.bottom-frame.top);
 	}
-	
+
 	if (B_OK == msg->FindString("txtComputer",&tmpC)) {
 		txtComputer->SetText(tmpC.String());
 	}
-	
+
 	if (B_OK == msg->FindString("txtUsername",&tmpU)) {
 		txtUsername->SetText(tmpU.String());
 	}
-	
+
 	if (B_OK == msg->FindString("txtPassword",&tmpP)) {
 		txtPassword->SetText(tmpP.String());
 	}
-	
+
 	if (B_OK == msg->FindString("txtDomain",&tmpD)) {
 		txtDomain->SetText(tmpD.String());
 	}
-	
+
 	if (B_OK == msg->FindInt32("chkForceBitmapUpdates",&FBU)) {
 		if (&FBU != 0) {
 			chkForceBitmapUpdates->SetValue(FBU);
-    	}	
+    	}
 	}
 	if (B_OK == msg->FindInt32("sldDisplaySize",&slide)) {
 		sldDisplaySize->SetValue(slide);
 	}
-	
+
 }
 // -------------------------------------------------------------------------------------------------- //
 
@@ -307,9 +307,9 @@ void BeRDPWindow::SaveConnectionList(void)
 {
 	BMessage msg;
 	int TotalMenuItems, Counter, NumberOfConnections;
-	
+
 	TotalMenuItems = pmnConnection->CountItems();
-	
+
 	if (TotalMenuItems > 5) {
 		NumberOfConnections =  TotalMenuItems - 5;
 		msg.AddInt32("NumberOfConnections",NumberOfConnections);
@@ -344,7 +344,7 @@ void BeRDPWindow::SaveConnectionDetails(const char *cnxname)
 	msg.AddString("txtDomain",txtDomain->Text());
 	msg.AddInt32("chkForceBitmapUpdates",chkForceBitmapUpdates->Value());
 	msg.AddInt32("sldDisplaySize",sldDisplaySize->Value());
-	
+
 	BPath path;
 	status_t result = find_directory(B_USER_SETTINGS_DIRECTORY,&path);
 	if (result == B_OK) {
@@ -365,7 +365,7 @@ void BeRDPWindow::SaveConnectionDetails(const char *cnxname)
 		cnxfilename.Append("/");
 		cnxfilename.Append(cnxname);
 		cnxfilename.Append(".berdp");
-		
+
 		//BMenuItem *CurrentItem = new BMenuItem(conmenufield);
 		//CurrentItem = conmenufield->FindMarked();
 		//printf("Save Connection Details Filename: %s / Total Items: %d\n\n",CurrentItem->Label(),
@@ -384,7 +384,7 @@ void BeRDPWindow::SaveSettings(const char *cnxname)
 	BMessage msg;
 	msg.AddRect("windowframe",Frame());
 	msg.AddString("cnxname",cnxname);
-	
+
 	// these will be moved to the function above shortly
 	//msg.AddString("txtComputer",txtComputer->Text());
 	//msg.AddString("txtUsername",txtUsername->Text());
@@ -392,7 +392,7 @@ void BeRDPWindow::SaveSettings(const char *cnxname)
 	//msg.AddString("txtDomain",txtDomain->Text());
 	//msg.AddInt32("chkForceBitmapUpdates",chkForceBitmapUpdates->Value());
 	//msg.AddInt32("sldDisplaySize",sldDisplaySize->Value());
-	
+
 	BPath path;
 	status_t result = find_directory(B_USER_SETTINGS_DIRECTORY,&path);
 	if (result == B_OK) {
@@ -425,7 +425,7 @@ void BeRDPWindow::UpdateDisplaySlider()
 			break;
 		case 5:
 			sldDisplaySize->SetLabel("Full Screen");
-			break;			
+			break;
 	}
 }
 // -------------------------------------------------------------------------------------------------- //
@@ -444,8 +444,8 @@ void BeRDPWindow::MessageReceived (BMessage *message)
 		cnxname.SetTo(pmnConnection->ItemAt(index)->Label()); // debug
 	} else {
 		cnxname.SetTo("");
-	}	
-	
+	}
+
 	switch(message->what)
 	{
 		case BTN_CONNECT:
@@ -453,7 +453,7 @@ void BeRDPWindow::MessageReceived (BMessage *message)
 				SaveConnectionDetails(cnxname.String()); // debug
 				SaveConnectionList();
 				SaveSettings(cnxname.String());
-				
+
 				BString cmdline;
 				cmdline.SetTo("rdesktop ");
 				switch (sldDisplaySize->Value())
@@ -475,9 +475,9 @@ void BeRDPWindow::MessageReceived (BMessage *message)
 					break;
 				case 5:
 					cmdline.Append("-f ");
-					break;			
+					break;
 				}
-				
+
 				BString tmpUsername;
 				tmpUsername.SetTo(txtUsername->Text());
 				if (tmpUsername.CountChars() > 0) {
@@ -495,10 +495,10 @@ void BeRDPWindow::MessageReceived (BMessage *message)
 
 				// Minimize the Window
 				Minimize(true);
-				
+
 				// Execute RDesktop
 				system(cmdline.String());
-				
+
 				// Now Show it Again
 				Minimize(false);
 			}
@@ -506,7 +506,7 @@ void BeRDPWindow::MessageReceived (BMessage *message)
 		case MENU_NEW_CONNECTION:
 			{
 				// Launch Window - Maybe my InputBox Class ?
-				
+
 				BMenuItem *marked = pmnConnection->FindItem("New Connection");
 				marked->SetMarked(true);
 			}
@@ -520,7 +520,7 @@ void BeRDPWindow::MessageReceived (BMessage *message)
 				txtDomain->SetText("");
 				sldDisplaySize->SetValue(3);
 				chkForceBitmapUpdates->SetValue(B_CONTROL_OFF);
-				
+
 				BMenuItem *marked = pmnConnection->FindItem("Default");
 				marked->SetMarked(true);
 			}
@@ -538,7 +538,7 @@ void BeRDPWindow::MessageReceived (BMessage *message)
 			{
 				UpdateDisplaySlider();
 			}
-			break;		
+			break;
 		default:
 			BWindow::MessageReceived(message);
 			break;

--- a/Source/BeRDPWindows.cpp
+++ b/Source/BeRDPWindows.cpp
@@ -8,7 +8,6 @@
  * BeRDP is a GUI for RDesktop
  */
 
-// Includes ------------------------------------------------------------------------------------------ //
 #include <Alert.h>
 #include <Application.h>
 #include <Button.h>
@@ -42,8 +41,6 @@
 #include "BeRDPWindows.h"
 #include "BeRDPViews.h"
 #include "BeRDPConstants.h"
-// -------------------------------------------------------------------------------------------------- //
-
 
 
 // CenterWindowOnScreen -- Centers the BWindow to the Current Screen
@@ -56,7 +53,7 @@ static void CenterWindowOnScreen(BWindow* w)
 	if (screenFrame.Contains(pt))
 		w->MoveTo(pt);
 }
-// -------------------------------------------------------------------------------------------------- //
+
 
 // BeRDPWindow - Constructor
 BeRDPWindow::BeRDPWindow(BRect frame) : BWindow (frame, "BeRDP", B_TITLED_WINDOW, B_NORMAL_WINDOW_FEEL , 0)
@@ -81,14 +78,14 @@ BeRDPWindow::BeRDPWindow(BRect frame) : BWindow (frame, "BeRDP", B_TITLED_WINDOW
 
 	Show();
 }
-// -------------------------------------------------------------------------------------------------- //
+
 
 // BeRDPWindow - Destructor
 BeRDPWindow::~BeRDPWindow()
 {
 	exit(0);
 }
-// -------------------------------------------------------------------------------------------------- //
+
 
 // BeRDPWindow::InitWindow -- Initialization Commands here
 void BeRDPWindow::InitWindow(void)
@@ -139,17 +136,6 @@ void BeRDPWindow::InitWindow(void)
 	mnfConnection->SetFont(be_bold_font);
 	mnfConnection->SetLowColor(ui_color(B_PANEL_BACKGROUND_COLOR));
 
-    /*conmenufield = new BMenu(" ... ");
-    conmenufield->AddItem(new BMenuItem(DefaultIP.String(), new BMessage(MENU_CONNECTION_DEFAULT)));
-    conmenufield->AddSeparatorItem();
-    conmenufield->AddItem(new BMenuItem("New Connection", new BMessage(MENU_NEW_CONNECTION)));
-    conmenufield->AddItem(menucondelete = new BMenuItem("Delete Current", new BMessage(MENU_CON_DELETE_CURRENT)));
-    menucondelete->SetEnabled(false);
-    connectionmenufield = new BMenuField(BRect (5,25,220,40),"connection_menu","Connection Name:",conmenufield,B_FOLLOW_LEFT | B_FOLLOW_TOP, B_WILL_DRAW | B_NAVIGABLE);
-    connectionmenufield->SetDivider(110);
-    connectionmenufield->SetFont(be_bold_font);
-    connectionmenufield->SetLowColor(ui_color(B_PANEL_BACKGROUND_COLOR));*/
-
     // Create TextControls for GeneralView
     txtComputer = new BTextControl(BRect (30,50,220,65), "txtComputer",
       					"Computer: ", "", new BMessage (TXT_COMPUTER),
@@ -192,8 +178,6 @@ void BeRDPWindow::InitWindow(void)
     sldDisplaySize->SetHashMarks(B_HASH_MARKS_BOTH);
     sldDisplaySize->SetLimitLabels("Less", "More");
     sldDisplaySize->SetValue(3);
-
-   // int wsleft = 175;
 
     // Add them all to Display Tab
     ptrDisplayView->AddChild(sldDisplaySize);
@@ -243,7 +227,6 @@ void BeRDPWindow::InitWindow(void)
 	AddChild(ptrBeRDPView = new BeRDPView(r));
 	ptrBeRDPView->AddChild(tabView);
 }
-// -------------------------------------------------------------------------------------------------- //
 
 
 // BeRDPWindow::QuitRequested -- Post a message to the app to quit
@@ -253,7 +236,6 @@ bool BeRDPWindow::QuitRequested()
 	be_app->PostMessage(B_QUIT_REQUESTED);
 	return true;
 }
-// -------------------------------------------------------------------------------------------------- //
 
 
 // BeRDPWindow::LoadSettings -- Loads your current settings
@@ -299,7 +281,6 @@ void BeRDPWindow::LoadSettings(BMessage *msg)
 	}
 
 }
-// -------------------------------------------------------------------------------------------------- //
 
 
 // BeRDPWindow::SaveConnectionList -- Saves the List of Conection Names from conmenufield
@@ -331,7 +312,6 @@ void BeRDPWindow::SaveConnectionList(void)
 		// Default Connection List - No Need to Save
 	}
 }
-// -------------------------------------------------------------------------------------------------- //
 
 
 // BeRDPWindow::SaveConnectionDetails -- Saves the Users settings
@@ -366,16 +346,11 @@ void BeRDPWindow::SaveConnectionDetails(const char *cnxname)
 		cnxfilename.Append(cnxname);
 		cnxfilename.Append(".berdp");
 
-		//BMenuItem *CurrentItem = new BMenuItem(conmenufield);
-		//CurrentItem = conmenufield->FindMarked();
-		//printf("Save Connection Details Filename: %s / Total Items: %d\n\n",CurrentItem->Label(),
-		//	conmenufield->CountItems());
 		path.SetTo(cnxfilename.String());
 		BFile file(path.Path(),B_READ_WRITE | B_CREATE_FILE | B_ERASE_FILE);
 		msg.Flatten(&file);
 	}
 }
-// -------------------------------------------------------------------------------------------------- //
 
 
 // BeRDPWindow::SaveSettings -- Saves the Users settings
@@ -385,14 +360,6 @@ void BeRDPWindow::SaveSettings(const char *cnxname)
 	msg.AddRect("windowframe",Frame());
 	msg.AddString("cnxname",cnxname);
 
-	// these will be moved to the function above shortly
-	//msg.AddString("txtComputer",txtComputer->Text());
-	//msg.AddString("txtUsername",txtUsername->Text());
-	//msg.AddString("txtPassword",txtPassword->Text());
-	//msg.AddString("txtDomain",txtDomain->Text());
-	//msg.AddInt32("chkForceBitmapUpdates",chkForceBitmapUpdates->Value());
-	//msg.AddInt32("sldDisplaySize",sldDisplaySize->Value());
-
 	BPath path;
 	status_t result = find_directory(B_USER_SETTINGS_DIRECTORY,&path);
 	if (result == B_OK) {
@@ -401,7 +368,6 @@ void BeRDPWindow::SaveSettings(const char *cnxname)
 		msg.Flatten(&file);
 	}
 }
-// -------------------------------------------------------------------------------------------------- //
 
 
 void BeRDPWindow::UpdateDisplaySlider()
@@ -428,7 +394,6 @@ void BeRDPWindow::UpdateDisplaySlider()
 			break;
 	}
 }
-// -------------------------------------------------------------------------------------------------- //
 
 
 // BeRDPWindow::MessageReceived -- receives messages
@@ -544,4 +509,3 @@ void BeRDPWindow::MessageReceived (BMessage *message)
 			break;
 	}
 }
-// -------------------------------------------------------------------------------------------------- //

--- a/Source/BeRDPWindows.cpp
+++ b/Source/BeRDPWindows.cpp
@@ -1,12 +1,12 @@
 /*
-
-BeRDPWindow
-
-Author: Sikosis (phil@sikosis.com)
-
-(C)2003-2004 Shell Created using BRIE (http://brie.sf.net/)
-
-*/
+ * Copyright 2003-2018. All rights reserved.
+ * Distributed under the terms of the BSD license.
+ *
+ * Author:
+ *	Sikosis, phil@sikosis.com
+ *
+ * BeRDP is a GUI for RDesktop
+ */
 
 // Includes ------------------------------------------------------------------------------------------ //
 #include <Alert.h>

--- a/Source/BeRDPWindows.h
+++ b/Source/BeRDPWindows.h
@@ -1,12 +1,12 @@
 /*
-
-BeRDP Windows Header
-
-Author: Sikosis (phil@sikosis.com)
-
-(C)2003-2004 Created using BRIE (http://brie.sf.net/)
-
-*/
+ * Copyright 2003-2018. All rights reserved.
+ * Distributed under the terms of the BSD license.
+ *
+ * Author:
+ *	Sikosis, phil@sikosis.com
+ *
+ * BeRDP is a GUI for RDesktop
+ */
 
 #ifndef __BeRDPWINDOWS_H__
 #define __BeRDPWINDOWS_H__

--- a/Source/BeRDPWindows.h
+++ b/Source/BeRDPWindows.h
@@ -40,7 +40,7 @@ class BeRDPWindow : public BWindow
 		virtual bool QuitRequested();
 		virtual void MessageReceived(BMessage *message);
 		virtual void UpdateDisplaySlider();
-		
+
 	private:
 		void InitWindow(void);
 
@@ -49,12 +49,12 @@ class BeRDPWindow : public BWindow
 		void LoadConnectionList(BMessage *msg);
 		void SaveConnectionList(void);
 		void SaveConnectionDetails(const char *cnxname);
-		
+
 		BeRDPView*		ptrBeRDPView;
 		GeneralView*    ptrGeneralView;
 		DisplayView*	ptrDisplayView;
 		AboutView*		ptrAboutView;
-		
+
 		BTabView		*tabView;
 	    BTab			*tab;
 	    BButton         *btnConnect;
@@ -63,7 +63,7 @@ class BeRDPWindow : public BWindow
 	    BSlider         *sldDisplaySize;
 	    BTextControl    *txtComputer;
 	    BTextControl    *txtUsername;
-	    BTextControl    *txtPassword; // I dont like to use this Password param 
+	    BTextControl    *txtPassword; // I dont like to use this Password param
 	    BTextControl    *txtDomain;   // (so it'll be greyed out)
 	    BStringView     *stvTitle;
 	    BStringView     *stvAuthor1;


### PR DESCRIPTION
- Standarized the copyright header format on all files
- Removed trailing white space
- Two lines between functions
- One line at end of file
- One space after starting a comment
- Removed full line seperator comments